### PR TITLE
Add build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,4 @@ jobs:
     - uses: actions/checkout@v1
     - run: npm install
     - run: npm run test
-    - run: npm run webpack
-    - run: npm run webext-build
+    - run: npm run build

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ $ npm install
 Build the extension with:
 
 ```
-$ npm run webpack
-$ npm run webext-build
+$ npm run build
 ```
 
 The resulting `estension-dist` can be manually installed on [Firefox]() and [Chrome/Chromium]().

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "./node_modules/karma/bin/karma start --single-run --browsers ChromeHeadless karma.conf.js",
     "webpack": "webpack",
-    "webext-build": "./node_modules/web-ext/bin/web-ext build"
+    "webext-build": "./node_modules/web-ext/bin/web-ext build",
+    "build": "npm run webpack; npm run webext-build; "
   },
   "devDependencies": {
     "copy-webpack-plugin": "^5.1.1",


### PR DESCRIPTION
Simplify the build process by combining `webpack`  and `webext-build` script into `build`.